### PR TITLE
Weak references to delegate and datasource

### DIFF
--- a/STCollapseTableView.podspec
+++ b/STCollapseTableView.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |s|
+  s.name             = "STCollapseTableView"
+  s.version          = "0.1.1"
+  s.summary          = "A UITableView subclass that automatically collapse and/or expand your sections."
+  s.description      = <<-DESC
+                    A UITableView subclass that automatically collapse and/or expand your sections.
+                    You just have to fill your datasource like for a classic UITableView and the magic will happen.
+                       DESC
+  s.homepage         = "https://github.com/iSofTom/STCollapseTableView"
+  s.license          = 'MIT'
+  s.author           = { "iSotTom" => "thomas@isoftom.com" }
+  s.source           = { :git => "https://github.com/iSofTom/STCollapseTableView.git", :tag => s.version.to_s }
+
+  s.platform     = :ios, '5.0'
+  s.requires_arc = true
+
+  s.source_files = 'STCollapseTableView/*.{h,m}'
+
+  s.frameworks = 'Foundation', 'UIKit'
+end

--- a/STCollapseTableView/STCollapseTableView.m
+++ b/STCollapseTableView/STCollapseTableView.m
@@ -34,8 +34,8 @@
 
 @interface STCollapseTableView () <UITableViewDataSource, UITableViewDelegate>
 
-@property (nonatomic, assign) id<UITableViewDataSource> collapseDataSource;
-@property (nonatomic, assign) id<UITableViewDelegate> collapseDelegate;
+@property (nonatomic, weak) id<UITableViewDataSource> collapseDataSource;
+@property (nonatomic, weak) id<UITableViewDelegate> collapseDelegate;
 @property (nonatomic, strong) NSMutableArray* sectionsStates;
 
 @end


### PR DESCRIPTION
Assign references throw EXC_BAD_ACCESS when a deallocated object is accessed.

Weak references became nil when the object gets deallocated, preventing crashes.
