### PR TITLE
Fix conversion warning

### DIFF
--- a/STCollapseTableView/STCollapseTableView.m
+++ b/STCollapseTableView/STCollapseTableView.m
@@ -271,7 +271,7 @@
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
 {
-	int nbSection = [self.collapseDataSource numberOfSectionsInTableView:tableView];
+	NSInteger nbSection = [self.collapseDataSource numberOfSectionsInTableView:tableView];
     
 	while (nbSection < [self.sectionsStates count])
     {


### PR DESCRIPTION
Fix warning: implicit conversion loses integer precision: 'NSIntege… …r' (aka 'long') to 'int'
